### PR TITLE
Issue#4 Add scrolling to recyclerview so elements can be verified safely

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,6 +137,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit:$testing_androidx_junit_version"
     testImplementation "androidx.test.espresso:espresso-core:$testing_espresso_version"
     testImplementation "androidx.test.espresso:espresso-intents:$testing_espresso_version"
+    testImplementation "androidx.test.espresso:espresso-contrib:$testing_espresso_version"
     testImplementation project(':mockserver')
     testImplementation "androidx.arch.core:core-testing:$testing_androidx_arch_core_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$testing_junit5_version"
@@ -151,6 +152,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$testing_androidx_junit_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$testing_espresso_version"
     androidTestImplementation "androidx.test.espresso:espresso-intents:$testing_espresso_version"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:$testing_espresso_version"
     androidTestImplementation project(':mockserver')
     androidTestImplementation "androidx.arch.core:core-testing:$testing_androidx_arch_core_version"
     androidTestRuntimeOnly "org.junit.vintage:junit-vintage-engine:$testing_junit5_version"
@@ -161,10 +163,3 @@ dependencies {
     implementation "io.reactivex.rxjava3:rxjava:3.1.2"
 }
 
-
-///Users/gergelyhegedus/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.5.31/ff5d99aecd328872494e8921b72bf6e3af97af3e/kotlin-stdlib-jdk8-1.5.31.jar (version 1.5)
-///Users/gergelyhegedus/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.5.31/77e0f2568912e45d26c31fd417a332458508acdf/kotlin-stdlib-jdk7-1.5.31.jar (version 1.5)
-///Users/gergelyhegedus/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.6.0/a40b8b22529b733892edf4b73468ce598bb17f04/kotlin-stdlib-1.6.0.jar (version 1.6)
-///Users/gergelyhegedus/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.6.0/7857e365f925cfa060f941c1357cda1f8790502c/kotlin-stdlib-common-1.6.0.jar (version 1.6)
-//w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
-//dagger.lint.DaggerIssueRegistry in /Users/gergelyhegedus/.gradle/caches/transforms-3/7d8d9a87fed97b25e3e147795231ede4/transformed/jetified-dagger-lint-aar-2.40/jars/lint.jar does not specify a vendor; see IssueRegistry#vendor

--- a/app/src/sharedTest/java/org/fnives/test/showcase/ui/home/HomeRobot.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/ui/home/HomeRobot.kt
@@ -1,9 +1,11 @@
 package org.fnives.test.showcase.ui.home
 
 import android.app.Instrumentation
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers
@@ -48,12 +50,15 @@ class HomeRobot : Robot {
         Espresso.onView(withId(R.id.logout_cta)).perform(click())
     }
 
-    fun assertContainsItem(item: FavouriteContent) = apply {
+    fun assertContainsItem(index: Int, item: FavouriteContent) = apply {
         val isFavouriteResourceId = if (item.isFavourite) {
             R.drawable.favorite_24
         } else {
             R.drawable.favorite_border_24
         }
+        Espresso.onView(withId(R.id.recycler))
+            .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(index))
+
         Espresso.onView(
             allOf(
                 withChild(allOf(withText(item.content.title), withId(R.id.title))),
@@ -64,7 +69,10 @@ class HomeRobot : Robot {
             .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     }
 
-    fun clickOnContentItem(item: Content) = apply {
+    fun clickOnContentItem(index: Int, item: Content) = apply {
+        Espresso.onView(withId(R.id.recycler))
+            .perform(RecyclerViewActions.scrollToPosition<RecyclerView.ViewHolder>(index))
+
         Espresso.onView(
             allOf(
                 withId(R.id.favourite_cta),

--- a/app/src/sharedTestHilt/java/org/fnives/test/showcase/ui/home/MainActivityTest.kt
+++ b/app/src/sharedTestHilt/java/org/fnives/test/showcase/ui/home/MainActivityTest.kt
@@ -105,8 +105,8 @@ class MainActivityTest {
         activityScenario = ActivityScenario.launch(HiltMainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        ContentData.contentSuccess.forEach {
-            homeRobot.assertContainsItem(FavouriteContent(it, false))
+        ContentData.contentSuccess.forEachIndexed { index, content ->
+            homeRobot.assertContainsItem(index, FavouriteContent(content, false))
         }
         homeRobot.assertDidNotNavigateToAuth()
     }
@@ -119,11 +119,11 @@ class MainActivityTest {
         activityScenario = ActivityScenario.launch(HiltMainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), true)
-        homeRobot.assertContainsItem(expectedItem)
+        homeRobot.assertContainsItem(0, expectedItem)
             .assertDidNotNavigateToAuth()
     }
 
@@ -135,7 +135,7 @@ class MainActivityTest {
         activityScenario = ActivityScenario.launch(HiltMainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), true)
@@ -144,7 +144,7 @@ class MainActivityTest {
         activityScenario = ActivityScenario.launch(HiltMainActivity::class.java)
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
-        homeRobot.assertContainsItem(expectedItem)
+        homeRobot.assertContainsItem(0, expectedItem)
             .assertDidNotNavigateToAuth()
     }
 
@@ -156,13 +156,13 @@ class MainActivityTest {
         activityScenario = ActivityScenario.launch(HiltMainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), false)
-        homeRobot.assertContainsItem(expectedItem)
+        homeRobot.assertContainsItem(0, expectedItem)
             .assertDidNotNavigateToAuth()
     }
 
@@ -194,8 +194,8 @@ class MainActivityTest {
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
         loopMainThreadFor(2000L)
 
-        ContentData.contentSuccess.forEach {
-            homeRobot.assertContainsItem(FavouriteContent(it, false))
+        ContentData.contentSuccess.forEachIndexed { index, content ->
+            homeRobot.assertContainsItem(index, FavouriteContent(content, false))
         }
         homeRobot.assertDidNotNavigateToAuth()
     }
@@ -236,8 +236,8 @@ class MainActivityTest {
         activityScenario = ActivityScenario.launch(HiltMainActivity::class.java)
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
-        ContentData.contentSuccess.forEach {
-            homeRobot.assertContainsItem(FavouriteContent(it, false))
+        ContentData.contentSuccess.forEachIndexed { index, content ->
+            homeRobot.assertContainsItem(index, FavouriteContent(content, false))
         }
         homeRobot.assertDidNotNavigateToAuth()
     }

--- a/app/src/sharedTestKoin/java/org/fnives/test/showcase/ui/home/MainActivityTest.kt
+++ b/app/src/sharedTestKoin/java/org/fnives/test/showcase/ui/home/MainActivityTest.kt
@@ -97,8 +97,8 @@ class MainActivityTest : KoinTest {
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        ContentData.contentSuccess.forEach {
-            homeRobot.assertContainsItem(FavouriteContent(it, false))
+        ContentData.contentSuccess.forEachIndexed { index, content ->
+            homeRobot.assertContainsItem(index, FavouriteContent(content, false))
         }
         homeRobot.assertDidNotNavigateToAuth()
     }
@@ -111,11 +111,11 @@ class MainActivityTest : KoinTest {
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), true)
-        homeRobot.assertContainsItem(expectedItem)
+        homeRobot.assertContainsItem(0, expectedItem)
             .assertDidNotNavigateToAuth()
     }
 
@@ -127,7 +127,7 @@ class MainActivityTest : KoinTest {
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), true)
@@ -136,7 +136,7 @@ class MainActivityTest : KoinTest {
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
-        homeRobot.assertContainsItem(expectedItem)
+        homeRobot.assertContainsItem(0, expectedItem)
             .assertDidNotNavigateToAuth()
     }
 
@@ -148,13 +148,13 @@ class MainActivityTest : KoinTest {
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
 
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
-        homeRobot.clickOnContentItem(ContentData.contentSuccess.first())
+        homeRobot.clickOnContentItem(0, ContentData.contentSuccess.first())
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), false)
-        homeRobot.assertContainsItem(expectedItem)
+        homeRobot.assertContainsItem(0, expectedItem)
             .assertDidNotNavigateToAuth()
     }
 
@@ -186,8 +186,8 @@ class MainActivityTest : KoinTest {
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
         loopMainThreadFor(2000L)
 
-        ContentData.contentSuccess.forEach {
-            homeRobot.assertContainsItem(FavouriteContent(it, false))
+        ContentData.contentSuccess.forEachIndexed { index, content ->
+            homeRobot.assertContainsItem(index, FavouriteContent(content, false))
         }
         homeRobot.assertDidNotNavigateToAuth()
     }
@@ -228,8 +228,8 @@ class MainActivityTest : KoinTest {
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 
-        ContentData.contentSuccess.forEach {
-            homeRobot.assertContainsItem(FavouriteContent(it, false))
+        ContentData.contentSuccess.forEachIndexed { index, content ->
+            homeRobot.assertContainsItem(index, FavouriteContent(content, false))
         }
         homeRobot.assertDidNotNavigateToAuth()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ task unitTests(dependsOn: ["app:testKoinDebugUnitTest", "app:testHiltDebugUnitTe
     description = 'Run all unit tests'
 }
 
+task robolectricTests(dependsOn: ["app:testKoinDebugUnitTest", "app:testHiltDebugUnitTest"]){
+    group = 'Tests'
+    description = 'Run all robolectric tests'
+}
+
 task androidTests(dependsOn: ["app:connectedKoinDebugAndroidTest", "app:connectedHiltDebugAndroidTest"]){
     group = 'Tests'
     description = 'Run all Android tests'

--- a/mockserver/src/main/java/org/fnives/test/showcase/network/mockserver/ContentData.kt
+++ b/mockserver/src/main/java/org/fnives/test/showcase/network/mockserver/ContentData.kt
@@ -17,7 +17,9 @@ object ContentData {
     val contentSuccess: List<Content> = listOf(
         Content(ContentId("1"), "title_1", "says_1", ImageUrl("img_1")),
         Content(ContentId("2"), "title_2", "says_2", ImageUrl("img_2")),
-        Content(ContentId("3"), "title_3", "says_3", ImageUrl("img_3"))
+        Content(ContentId("3"), "title_3", "says_3", ImageUrl("img_3")),
+        Content(ContentId("4"), "title_4", "says_4", ImageUrl("img_4")),
+        Content(ContentId("5"), "title_5", "says_5", ImageUrl("img_5"))
     )
 
     /**

--- a/mockserver/src/main/resources/response/content/success_response_content.json
+++ b/mockserver/src/main/resources/response/content/success_response_content.json
@@ -16,5 +16,17 @@
     "title": "title_3",
     "says": "says_3",
     "image": "img_3"
+  },
+  {
+    "id": "4",
+    "title": "title_4",
+    "says": "says_4",
+    "image": "img_4"
+  },
+  {
+    "id": "5",
+    "title": "title_5",
+    "says": "says_5",
+    "image": "img_5"
   }
 ]


### PR DESCRIPTION
### **https://github.com/fknives/AndroidTest-ShowCase/issues/4 Update RecyclerView tests with Espresso.onData**

Fixing issue with tests checkin RecyclerView elements.

### Issue
Previously we expected that all views are visible on the screen and just checked that. However this is not the correct approach, since RecyclerView items can be outside of the screen.

### Changes
Added Espresso.onData to scroll to the item being checked. After that we can be sure the View to be checked is on the screen so we can safely verify it's properties.

