### PR TITLE
Issue#39 Fix most test's running time via using close on ActivityScenario.

### DIFF
--- a/app/src/sharedTest/java/org/fnives/test/showcase/testutils/statesetup/SetupAuthenticationState.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/testutils/statesetup/SetupAuthenticationState.kt
@@ -29,7 +29,7 @@ object SetupAuthenticationState : KoinTest {
 
         mainDispatcherTestRule.advanceUntilIdleOrActivityIsDestroyed()
 
-        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        activityScenario.close()
     }
 
     fun setupLogout(
@@ -43,6 +43,6 @@ object SetupAuthenticationState : KoinTest {
 
         mainDispatcherTestRule.advanceUntilIdleOrActivityIsDestroyed()
 
-        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        activityScenario.close()
     }
 }

--- a/app/src/sharedTest/java/org/fnives/test/showcase/ui/home/MainActivityTest.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/ui/home/MainActivityTest.kt
@@ -1,7 +1,6 @@
 package org.fnives.test.showcase.ui.home
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.fnives.test.showcase.model.content.FavouriteContent
@@ -73,7 +72,7 @@ class MainActivityTest : KoinTest {
 
     @After
     fun tearDown() {
-        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        activityScenario.close()
         disposable.dispose()
     }
 
@@ -130,7 +129,7 @@ class MainActivityTest : KoinTest {
 
         val expectedItem = FavouriteContent(ContentData.contentSuccess.first(), true)
 
-        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        activityScenario.close()
         activityScenario = ActivityScenario.launch(MainActivity::class.java)
         mainDispatcherTestRule.advanceUntilIdleWithIdlingResources()
 

--- a/app/src/sharedTest/java/org/fnives/test/showcase/ui/login/AuthActivityTest.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/ui/login/AuthActivityTest.kt
@@ -1,7 +1,6 @@
 package org.fnives.test.showcase.ui.login
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.fnives.test.showcase.R
@@ -63,7 +62,7 @@ class AuthActivityTest : KoinTest {
 
     @After
     fun tearDown() {
-        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        activityScenario.close()
         disposable.dispose()
     }
 

--- a/app/src/sharedTest/java/org/fnives/test/showcase/ui/splash/SplashActivityTest.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/ui/splash/SplashActivityTest.kt
@@ -51,7 +51,7 @@ class SplashActivityTest : KoinTest {
 
     @After
     fun tearDown() {
-        activityScenario.moveToState(Lifecycle.State.DESTROYED)
+        activityScenario.close()
         disposable.dispose()
     }
 


### PR DESCRIPTION
Resolves most slow tests mentioned in issue #39 

However the SplashActivity tests' happy flow still seems to be stuck for 30 seconds.