### PR TITLE
issue#64 Fix issue with idling resources

### DIFF
--- a/app/src/sharedTest/java/org/fnives/test/showcase/testutils/idling/OkHttp3IdlingResource.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/testutils/idling/OkHttp3IdlingResource.kt
@@ -19,7 +19,11 @@ class OkHttp3IdlingResource private constructor(
     var callback: IdlingResource.ResourceCallback? = null
 
     init {
-        dispatcher.idleCallback = Runnable { callback?.onTransitionToIdle() }
+        val currentCallback = dispatcher.idleCallback
+        dispatcher.idleCallback = Runnable {
+            callback?.onTransitionToIdle()
+            currentCallback?.run()
+        }
     }
 
     override fun getName(): String = name


### PR DESCRIPTION
reference: https://github.com/JakeWharton/okhttp-idling-resource/pull/16
Espresso expects callback when a resource is released. However since our OkHttp Dispatchers were reused and 2 compiting IdlingResource was registered, one overwrote the other's callback and this crashed the Espresso tests.
To resolve this I made sure when one is registeres, it's respects the current callback and wraps around it instead of overwriting it.