### PR TITLE
Issue#97 Attempt to fix flakiness in Compose

### DIFF
--- a/app/src/sharedTest/java/org/fnives/test/showcase/testutils/idling/DatabaseDispatcherTestRule.kt
+++ b/app/src/sharedTest/java/org/fnives/test/showcase/testutils/idling/DatabaseDispatcherTestRule.kt
@@ -3,7 +3,7 @@ package org.fnives.test.showcase.testutils.idling
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
-import org.fnives.test.showcase.android.testutil.synchronization.idlingresources.anyResourceIdling
+import org.fnives.test.showcase.android.testutil.synchronization.idlingresources.anyResourceNotIdle
 import org.fnives.test.showcase.android.testutil.synchronization.idlingresources.awaitIdlingResources
 import org.fnives.test.showcase.android.testutil.synchronization.runOnUIAwaitOnCurrent
 import org.fnives.test.showcase.testutils.storage.TestDatabaseInitialization
@@ -42,7 +42,7 @@ class DatabaseDispatcherTestRule : TestRule {
     companion object {
         fun TestDispatcher.advanceUntilIdleWithIdlingResources() {
             scheduler.advanceUntilIdle() // advance until a request is sent
-            while (anyResourceIdling()) { // check if any request is in progress
+            while (anyResourceNotIdle()) { // check if any request is in progress
                 awaitIdlingResources() // complete all requests and other idling resources
                 scheduler.advanceUntilIdle() // run coroutines after request is finished
             }

--- a/test-util-android/src/main/java/org/fnives/test/showcase/android/testutil/synchronization/MainDispatcherTestRule.kt
+++ b/test-util-android/src/main/java/org/fnives/test/showcase/android/testutil/synchronization/MainDispatcherTestRule.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.fnives.test.showcase.android.testutil.synchronization.idlingresources.anyResourceIdling
+import org.fnives.test.showcase.android.testutil.synchronization.idlingresources.anyResourceNotIdle
 import org.fnives.test.showcase.android.testutil.synchronization.idlingresources.awaitIdlingResources
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -54,7 +54,7 @@ open class MainDispatcherTestRule(private val useStandard: Boolean = true) : Tes
     companion object {
         fun TestDispatcher.advanceUntilIdleWithIdlingResources() {
             scheduler.advanceUntilIdle() // advance until a request is sent
-            while (anyResourceIdling()) { // check if any request is in progress
+            while (anyResourceNotIdle()) { // check if any request is in progress
                 awaitIdlingResources() // complete all requests and other idling resources
                 scheduler.advanceUntilIdle() // run coroutines after request is finished
             }

--- a/test-util-android/src/main/java/org/fnives/test/showcase/android/testutil/synchronization/idlingresources/IdlingResourcesHelper.kt
+++ b/test-util-android/src/main/java/org/fnives/test/showcase/android/testutil/synchronization/idlingresources/IdlingResourcesHelper.kt
@@ -6,7 +6,7 @@ import org.fnives.test.showcase.android.testutil.synchronization.loopMainThreadF
 import java.util.concurrent.Executors
 
 // workaround, issue with idlingResources is tracked here https://github.com/robolectric/robolectric/issues/4807
-fun anyResourceIdling(): Boolean = !IdlingRegistry.getInstance().resources.all(IdlingResource::isIdleNow)
+fun anyResourceNotIdle(): Boolean = (!IdlingRegistry.getInstance().resources.all(IdlingResource::isIdleNow))
 
 fun awaitIdlingResources() {
     val idlingRegistry = IdlingRegistry.getInstance()
@@ -30,7 +30,7 @@ fun awaitIdlingResources() {
     executor.shutdown()
 }
 
-private fun IdlingResource.awaitUntilIdle() {
+fun IdlingResource.awaitUntilIdle() {
     // using loop because some times, registerIdleTransitionCallback wasn't called
     while (true) {
         if (isIdleNow) return


### PR DESCRIPTION
The flakiness is caused by timeout when waiting for idling resources.
To circumvent this, we will always await the idling resources, and at the start we will only wait for compose-time, to navigate away from Splash.