### PR TITLE
Issue#107 resolve state restoration

### DIFF
--- a/app/src/androidTest/java/org/fnives/test/showcase/ui/AuthComposeInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/fnives/test/showcase/ui/AuthComposeInstrumentedTest.kt
@@ -175,6 +175,7 @@ class AuthComposeInstrumentedTest : KoinTest {
             .assertPassword("banan")
 
         stateRestorationTester.emulateSavedInstanceStateRestore()
+        composeTestRule.mainClock.advanceTimeBy(SPLASH_DELAY) // ensure all time based operation run
 
         navigationRobot.assertAuthScreen()
         robot.assertUsername("alma")

--- a/app/src/main/java/org/fnives/test/showcase/compose/screen/AppNavigation.kt
+++ b/app/src/main/java/org/fnives/test/showcase/compose/screen/AppNavigation.kt
@@ -24,9 +24,11 @@ fun AppNavigation(isUserLogeInUseCase: IsUserLoggedInUseCase = get()) {
     val navController = rememberNavController()
 
     LaunchedEffect(isUserLogeInUseCase) {
+        val loginStateRoute = if (isUserLogeInUseCase.invoke()) RouteTag.HOME else RouteTag.AUTH
+        if (navController.currentDestination?.route == loginStateRoute) return@LaunchedEffect
         delay(500)
         navController.navigate(
-            route = if (isUserLogeInUseCase.invoke()) RouteTag.HOME else RouteTag.AUTH,
+            route = loginStateRoute,
             navOptions = NavOptions.Builder().setPopUpTo(route = RouteTag.SPLASH, inclusive = true).build()
         )
     }

--- a/codekata/compose.instructionset.md
+++ b/codekata/compose.instructionset.md
@@ -184,7 +184,7 @@ mockServerScenarioSetup.setScenario(
 
 Then we wait a bit, more precisely we wait for the app to navigate us correctly to AuthScreen since we're not logged in:
 ```kotlin
-composeTestRule.mainClock.advanceTimeBy(510L)
+composeTestRule.mainClock.advanceTimeBy(600L)
 ```
 
 We assert that we are indeed on the correct screen
@@ -227,7 +227,7 @@ Next up we verify what happens if the user doesn't set their password. We don't 
 
 First we check that we are in the write place:
 ```kotlin
-composeTestRule.mainClock.advanceTimeBy(510L)
+composeTestRule.mainClock.advanceTimeBy(600L)
 navigationRobot.assertAuthScreen()
 ```
 
@@ -252,7 +252,7 @@ This will be really similar as the previous test, so try to do it on your own. T
 
 Still, here is the complete code:
 ```kotlin
-composeTestRule.mainClock.advanceTimeBy(510L)
+composeTestRule.mainClock.advanceTimeBy(600L)
 navigationRobot.assertAuthScreen()
 
 robot
@@ -277,7 +277,7 @@ mockServerScenarioSetup.setScenario(
 
 Now input the credentials and fire the event:
 ```kotlin
-composeTestRule.mainClock.advanceTimeBy(510L)
+composeTestRule.mainClock.advanceTimeBy(600L)
 navigationRobot.assertAuthScreen()
 robot.setUsername("alma")
     .setPassword("banan")
@@ -310,7 +310,7 @@ mockServerScenarioSetup.setScenario(
     AuthScenario.GenericError(username = "alma", password = "banan")
 )
 
-composeTestRule.mainClock.advanceTimeBy(510L)
+composeTestRule.mainClock.advanceTimeBy(600L)
 navigationRobot.assertAuthScreen()
 robot.setUsername("alma")
     .setPassword("banan")
@@ -342,8 +342,10 @@ Then in `setup()`, we need to `setContent` on `stateRestorationTester` instead o
 
 Now for the actual test, we first setup the content then we trigger restoration by calling `stateRestorationTester.emulateSavedInstanceStateRestore()`, afterwards we can verify that the content is recreated in the correct way:
 
+> Note: We also add the time advancement, to ensure no time based effect messes up anything!
+
 ```kotlin
-composeTestRule.mainClock.advanceTimeBy(510L)
+composeTestRule.mainClock.advanceTimeBy(600L)
 navigationRobot.assertAuthScreen()
 robot.setUsername("alma")
     .setPassword("banan")
@@ -351,6 +353,7 @@ robot.setUsername("alma")
     .assertPassword("banan")
 
 stateRestorationTester.emulateSavedInstanceStateRestore()
+composeTestRule.mainClock.advanceTimeBy(600L)
 
 navigationRobot.assertAuthScreen()
 robot.assertUsername("alma")


### PR DESCRIPTION
Implementation of the findings on issue #107 

>The test itself is not completely wrong, it just doesn't wait enough.
>
>The implementation is incorrect, and the test points that out sometimes:
>
>When the Restoration happens, the whole composable is recreated
>=> This means the LaunchedEffect as well, which navigates away from the Splash screen
>=> This means after 500 millis we navigate again to Splash screen, even if we are already there
>=> The restoration state is lost, since we popup and only show the new screen which has no saved state.
>To resolve:
>=> Add advanceTimeBy after restoration, to ensure all time based operations run as well
>=> Then modify the implementation so the State Restoration becomes correct